### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -100,7 +100,7 @@
        internal tick frequencies. Timing is non-deterministic when calling
        the Linux kernel so some averaging and smoothing of the resulting jitter
        is helpful. If EpikTimer is in this mode, long term accuracy isn't
-       guaranteed... but short term comparitive measurements can still be made.
+       guaranteed... but short term comparative measurements can still be made.
        
        Pressing "Calibrate" performs overhead extraction and gates the selected
        timebase against the best timebase gate available on a given host. The 


### PR DESCRIPTION
@graemeg, I've corrected a typographical error in the documentation of the [epiktimer](https://github.com/graemeg/epiktimer) project. Specifically, I've changed comparitive to comparative. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
